### PR TITLE
Update kafka0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ To use logback-kafka in your project add to following to your pom.xml:
 <dependency>
     <groupId>com.github.ptgoetz</groupId>
     <artifactId>logback-kafka</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
 ## Configuration
 
-To configure your application to log to kafka, add an appender entry in your logback configuration file, and specify 
+To configure your application to log to kafka, add an appender entry in your logback configuration file, and specify
 a zookeeper host string, and kafka topic name to log to.
 
 
@@ -27,7 +27,14 @@ a zookeeper host string, and kafka topic name to log to.
     <appender name="KAFKA"
         class="com.github.ptgoetz.logback.kafka.KafkaAppender">
         <topic>mytopic</topic>
-        <zookeeperHost>localhost:2181</zookeeperHost>
+        <!-- Any configuration property defined here
+        https://kafka.apache.org/documentation.html#producerconfigs
+        will be passed through to the Kafka Producer: -->
+        <kafkaProducerProperties>
+            bootstrap.servers=127.0.0.1:9092
+            acks=all
+        </kafkaProducerProperties>
+        <logToSystemOut>true</logToSystemOut>
     </appender>
     <root level="debug">
         <appender-ref ref="KAFKA" />
@@ -36,7 +43,7 @@ a zookeeper host string, and kafka topic name to log to.
 ```
 
 ## Overriding Default Behavior
-By default, the Kafka appender will simply write the received log message to the kafka queue. You can override this 
+By default, the Kafka appender will simply write the received log message to the kafka queue. You can override this
 behavior by specifying a custom formatter class:
 
 ```xml
@@ -45,16 +52,24 @@ behavior by specifying a custom formatter class:
     <appender name="KAFKA"
         class="com.github.ptgoetz.logback.kafka.KafkaAppender">
         <topic>foo</topic>
-        <zookeeperHost>localhost:2181</zookeeperHost>
+        <!-- Any configuration property defined here
+        https://kafka.apache.org/documentation.html#producerconfigs
+        will be passed through to the Kafka Producer: -->
+        <kafkaProducerProperties>
+            bootstrap.servers=127.0.0.1:9092
+            acks=all
+        </kafkaProducerProperties>
         <!-- specify a custom formatter -->
         <formatter class="com.github.ptgoetz.logback.kafka.formatter.JsonFormatter">
-            <!-- 
+            <!--
             Whether we expect the log message to be JSON encoded or not.
-            If set to "false", the log message will be treated as a string, 
+            If set to "false", the log message will be treated as a string,
             and wrapped in quotes. Otherwise it will be treated as a parseable
             JSON object.
             -->
             <expectJson>true</expectJson>
+            <!-- optional -->
+            <includeMethodAndLineNumber>true</includeMethodAndLineNumber>
         </formatter>
     </appender>
     <root level="debug">
@@ -78,6 +93,5 @@ public interface Formatter {
 ```
 
 You can find the `ch.qos.logback.classic.spi.ILoggingEvent` javadoc [here](http://logback.qos.ch/apidocs/ch/qos/logback/classic/spi/ILoggingEvent.html).
-
 
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To use logback-kafka in your project add to following to your pom.xml:
 To configure your application to log to Kafka, add an appender entry in 
 your logback configuration file, a Kafka topic name to log to, 
 and specify your Kafka Producer properties. At a minimum, you must 
-provide the 'bootstrap.servers' property. The properties you submit 
-will be passed on to the Kafka Producer. A complete guide to the Producer 
+provide the 'bootstrap.servers', 'key.serializer', and 'value.serializer' properties. 
+The properties you submit will be passed on to the Kafka Producer. A complete guide to the Producer 
 properties can be found [here](https://kafka.apache.org/documentation.html#producerconfigs).
 
 An option to log to System out is provided as a sanity check while setting up.
@@ -34,7 +34,8 @@ An option to log to System out is provided as a sanity check while setting up.
         <topic>mytopic</topic>
         <kafkaProducerProperties>
             bootstrap.servers=127.0.0.1:9092
-            acks=all
+            value.serializer=org.apache.kafka.common.serialization.StringSerializer
+            key.serializer=org.apache.kafka.common.serialization.StringSerializer
         </kafkaProducerProperties>
         <logToSystemOut>true</logToSystemOut>
     </appender>
@@ -60,7 +61,8 @@ specifying a custom formatter class:
         will be passed through to the Kafka Producer: -->
         <kafkaProducerProperties>
             bootstrap.servers=127.0.0.1:9092
-            acks=all
+            value.serializer=org.apache.kafka.common.serialization.StringSerializer
+            key.serializer=org.apache.kafka.common.serialization.StringSerializer
         </kafkaProducerProperties>
         <!-- specify a custom formatter -->
         <formatter class="com.github.ptgoetz.logback.kafka.formatter.JsonFormatter">

--- a/README.md
+++ b/README.md
@@ -17,16 +17,14 @@ To use logback-kafka in your project add to following to your pom.xml:
 
 ## Configuration
 
-To configure your application to log to kafka, add an appender entry in 
-your logback configuration file, a kafka topic name to log to, 
-and specify your Kafka Producer Properties. At a minimum, you must 
-provide the 'bootstrap.servers' property. Al the properties you submit 
-will be passed on to the Kafka Producer. A guide to the properties can 
-be found here: 
-https://kafka.apache.org/documentation.html#producerconfigs
+To configure your application to log to Kafka, add an appender entry in 
+your logback configuration file, a Kafka topic name to log to, 
+and specify your Kafka Producer properties. At a minimum, you must 
+provide the 'bootstrap.servers' property. The properties you submit 
+will be passed on to the Kafka Producer. A complete guide to the Producer 
+properties can be found [here](https://kafka.apache.org/documentation.html#producerconfigs).
 
-There is also an option to log to System out,
- as a sanity check while setting up.
+An option to log to System out is provided as a sanity check while setting up.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -82,7 +80,6 @@ specifying a custom formatter class:
     </root>
 </configuration>
 ```
-
 
 Formatters simply need to implement the `com.github.ptgoetz.logback.kafka.formatter.Formatter` interface:
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ To use logback-kafka in your project add to following to your pom.xml:
 
 ## Configuration
 
-To configure your application to log to kafka, add an appender entry in your logback configuration file, and specify
-a zookeeper host string, and kafka topic name to log to.
+To configure your application to log to kafka, add an appender entry in 
+your logback configuration file, a kafka topic name to log to, 
+and specify your Kafka Producer Properties. At a minimum, you must 
+provide the 'bootstrap.servers' property. Al the properties you submit 
+will be passed on to the Kafka Producer. A guide to the properties can 
+be found here: 
+https://kafka.apache.org/documentation.html#producerconfigs
 
+There is also an option to log to System out,
+ as a sanity check while setting up.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -27,9 +34,6 @@ a zookeeper host string, and kafka topic name to log to.
     <appender name="KAFKA"
         class="com.github.ptgoetz.logback.kafka.KafkaAppender">
         <topic>mytopic</topic>
-        <!-- Any configuration property defined here
-        https://kafka.apache.org/documentation.html#producerconfigs
-        will be passed through to the Kafka Producer: -->
         <kafkaProducerProperties>
             bootstrap.servers=127.0.0.1:9092
             acks=all
@@ -43,8 +47,9 @@ a zookeeper host string, and kafka topic name to log to.
 ```
 
 ## Overriding Default Behavior
-By default, the Kafka appender will simply write the received log message to the kafka queue. You can override this
-behavior by specifying a custom formatter class:
+By default, the Kafka appender will simply write the received log 
+message to the kafka queue. You can override this behavior by 
+specifying a custom formatter class:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -77,7 +82,6 @@ behavior by specifying a custom formatter class:
     </root>
 </configuration>
 ```
-
 
 
 Formatters simply need to implement the `com.github.ptgoetz.logback.kafka.formatter.Formatter` interface:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,19 @@
 
 	<groupId>com.github.ptgoetz</groupId>
 	<artifactId>logback-kafka</artifactId>
-	<version>0.1.1-SNAPSHOT</version>
+	<version>0.2-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<packaging>jar</packaging>
 
 	<parent>
@@ -50,22 +62,12 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.0.13</version>
+			<version>1.1.7</version>
 		</dependency>
 		<dependency>
-			<groupId>kafka</groupId>
-			<artifactId>kafka</artifactId>
-			<version>0.7.1</version>
-		</dependency>
-		<dependency>
-			<groupId>org.scala-lang</groupId>
-			<artifactId>scala-library</artifactId>
-			<version>2.8.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.sgroschupf</groupId>
-			<artifactId>zkclient</artifactId>
-			<version>0.1</version>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>0.10.0.0</version>
 		</dependency>
 		<dependency>
 			<artifactId>slf4j-api</artifactId>

--- a/src/main/java/com/github/ptgoetz/logback/kafka/KafkaAppender.java
+++ b/src/main/java/com/github/ptgoetz/logback/kafka/KafkaAppender.java
@@ -34,9 +34,11 @@ public class KafkaAppender extends AppenderBase<ILoggingEvent> {
         }
 
         if (topic == null) {
+            LOGGER.error("KafkaAppender requires a topic. Add this to the appender configuration.");
             System.out.println("KafkaAppender requires a topic. Add this to the appender configuration.");
         } else {
-            System.out.println("KafkaAppender will produce messages for the '" + topic + "' topic.");
+            LOGGER.info("KafkaAppender will publish messages to the '{}' topic.",topic);
+            System.out.println("KafkaAppender will publish messages to the '" + topic + "' topic.");
         }
         LOGGER.info("kafkaProducerProperties = {}", kafkaProducerProperties);
         LOGGER.info("Kafka Producer Properties = {}", properties);
@@ -56,7 +58,6 @@ public class KafkaAppender extends AppenderBase<ILoggingEvent> {
     @Override
     protected void append(ILoggingEvent event) {
         String string = this.formatter.format(event);
-        LOGGER.trace("Appending string: {}", string);
         if (logToSystemOut) {
             System.out.println("KafkaAppender: Appending string: '" + string + "'.");
         }

--- a/src/main/java/com/github/ptgoetz/logback/kafka/formatter/JsonFormatter.java
+++ b/src/main/java/com/github/ptgoetz/logback/kafka/formatter/JsonFormatter.java
@@ -1,6 +1,5 @@
 package com.github.ptgoetz.logback.kafka.formatter;
 
-import ch.qos.logback.classic.spi.CallerData;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class JsonFormatter implements Formatter {

--- a/src/main/java/com/github/ptgoetz/logback/kafka/formatter/JsonFormatter.java
+++ b/src/main/java/com/github/ptgoetz/logback/kafka/formatter/JsonFormatter.java
@@ -1,5 +1,6 @@
 package com.github.ptgoetz.logback.kafka.formatter;
 
+import ch.qos.logback.classic.spi.CallerData;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class JsonFormatter implements Formatter {
@@ -8,6 +9,7 @@ public class JsonFormatter implements Formatter {
     private static final String COMMA = ",";
 
     private boolean expectJson = false;
+    private boolean includeMethodAndLineNumber = false;
 
     public String format(ILoggingEvent event) {
         StringBuilder sb = new StringBuilder();
@@ -27,7 +29,19 @@ public class JsonFormatter implements Formatter {
         } else {
             quote(event.getFormattedMessage(), sb);
         }
-
+        if(includeMethodAndLineNumber) {
+            sb.append(COMMA);
+            // Caller Data
+            StackTraceElement[] callerDataArray = event.getCallerData();
+            if (callerDataArray != null && callerDataArray.length > 0) {
+                StackTraceElement stackTraceElement = callerDataArray[0];
+                fieldName("method", sb);
+                quote(stackTraceElement.getMethodName(), sb);
+                sb.append(COMMA);
+                fieldName("lineNumber", sb);
+                quote(stackTraceElement.getLineNumber() + "", sb);
+            }
+        }
         sb.append("}");
         return sb.toString();
     }
@@ -43,11 +57,19 @@ public class JsonFormatter implements Formatter {
         sb.append(QUOTE);
     }
 
-    public boolean isExpectJson() {
+    public boolean getExpectJson() {
         return expectJson;
     }
 
     public void setExpectJson(boolean expectJson) {
         this.expectJson = expectJson;
+    }
+
+    public boolean getIncludeMethodAndLineNumber() {
+        return includeMethodAndLineNumber;
+    }
+
+    public void setIncludeMethodAndLineNumber(boolean includeMethodAndLineNumber) {
+        this.includeMethodAndLineNumber = includeMethodAndLineNumber;
     }
 }


### PR DESCRIPTION
Hi Taylor,

The submitted changes provide the following:
1. Updated to work with Kafka 0.10. (And will likely work with any version after 0.8, but this has not been tested)
2. Provides a simple properties "pass-through" mechanism, so that all 49 Kafka Producer properties can be leveraged. This also means the appender will require less maintenance as these properties evolve in Kafka 0.11+ as long as the core Producer initialization remains constant.
3. Added an option to log to System out while setting up. 
4. Added an option to log method and line number in the JSONFormatter.

There is another decent appender out there by D. Wegener, but this appender's property "pass-through" strategy is simpler and more powerful, imho.

Thanks,
John Page

Note: Yes, we used to work together. You may recall, we went to an ETE together. I hope you're doing well!
